### PR TITLE
Set cipher_default_compatibility to level 3

### DIFF
--- a/authplus-to-andotp.py
+++ b/authplus-to-andotp.py
@@ -25,6 +25,7 @@ elif args.password is None:
 
 conn = sqlite.connect(args.db_name)
 cur = conn.cursor()
+cur.execute(f"PRAGMA cipher_default_compatibility = 3")
 cur.execute(f"PRAGMA key='{args.password}'")
 cur.execute("SELECT * FROM accounts ORDER BY position ASC")
 account_rows = cur.fetchall()


### PR DESCRIPTION
The version 4 changed default settings for ciphers. (https://www.zetetic.net/blog/2018/11/30/sqlcipher-400-release/)

Authenticator Plus is using version 3 settings.


Should fix #1 