### PR TITLE
Dockerify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.12
+LABEL maintainer="adiov"
+
+RUN apk add --update-cache git \
+  build-base \
+  openssl-dev \
+  tcl \
+  python3 \
+  py3-setuptools \
+  python3-dev \
+  && git clone --depth 1 --branch v3.4.2 https://github.com/sqlcipher/sqlcipher.git \
+  && cd sqlcipher \
+  && ./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto" \
+  && make \
+  && make install \
+  && git clone --depth 1 https://github.com/rigglemania/pysqlcipher3.git \
+  && cd pysqlcipher3 \
+  && python3 setup.py build \
+  && python3 setup.py install
+
+WORKDIR /authplus-to-andotp
+
+ENTRYPOINT ["/usr/bin/python3", "/authplus-to-andotp/authplus-to-andotp.py"]

--- a/README.md
+++ b/README.md
@@ -1,43 +1,48 @@
 # Authenticator Plus to andOTP Magiculator
+
 The [Authenticator Plus app](https://play.google.com/store/apps/details?id=com.mufri.authenticatorplus) seems to have been abandoned by the developer. [andOTP](https://github.com/andOTP/andOTP) is a decent, open source, alternative.
 
 This converts the Authenticator Plus backup database into andOTP-compatible backup database that can be directly important into andOTP.
 
 # Installation
+
+### With Docker
+
+```
+$ docker build -t authplus-to-andotp-magiculator .
+```
+
+### Without Docker
+
 The only dependency is [`pysqlcipher3`](https://github.com/rigglemania/pysqlcipher3). On my machine, I installed it like this:
 ```
-sudo apt install -y libsqlcipher-dev
-git clone https://github.com/rigglemania/pysqlcipher3
-cd pysqlcipher3
-python3 setup.py build
-sudo python3 setup.py install
+$ sudo apt install -y libsqlcipher-dev
+$ git clone https://github.com/rigglemania/pysqlcipher3
+$ cd pysqlcipher3
+$ python3 setup.py build
+$ sudo python3 setup.py install
 ```
 
 # Usage
-```
-./authplus-to-andotp.py -h
-usage: authplus-to-andotp.py [-h] [-d DB_NAME] [-o OUT_FILE] [-p PASSWORD]
 
-Convert Authenticator Plus OTP backup database into andOTP backup database
+### With Docker:
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -d DB_NAME, --database DB_NAME
-                        Authenticator Plus database, usually authplus.db
-  -o OUT_FILE, --output-file OUT_FILE
-                        Output file name. Defaults to andOTP.json
-  -p PASSWORD, --password PASSWORD
-                        Authenticator Plus master password (don't set if you
-                        wanna type password in a prompt instead)
 ```
-
-Example:
-```
-./authplus-to-andotp.py --database authplus.db
+$ docker run -v ${PWD}:/authplus-to-andotp -it authplus-to-andotp-magiculator --database authplus.db
 Authenticator Plus master password:
+andotp.json is now ready.
 ```
 
-## Caveats
+### Without Docker:
+
+```
+$ ./authplus-to-andotp.py --database authplus.db
+Authenticator Plus master password:
+andotp.json is now ready.
+```
+
+## Notes
+
 - This will decrypt the Authenticator Plus backup database and output the andOTP backup database in decrypted plain-text. Be careful how you handle that.
 - This attempts to preserve the entries' icons/thumbnails by using the `Issuer` field as `thumbnail`, which doesn't have a 100% success rate, but should work most of the time.
 - As far as I can tell, Authenticator Plus doesn't handle checksum algorithms other than SHA-1 or OTP digits other than 6. The output file will use those values by default. The only exception seems to be Battle.net TOTP with which Authenticator Plus uses 8 digits; this script attempts to preserve this info and pass it to andOTP.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ sudo python3 setup.py install
 ### With Docker:
 
 ```
+$ git clone https://github.com/adiov/authplus-to-andotp-magiculator.git
+$ cd authplus-to-andotp-magiculator
 $ docker run -v ${PWD}:/authplus-to-andotp -it adiov/authplus-to-andotp-magiculator --database authplus.db
 Authenticator Plus master password:
 andotp.json is now ready.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This converts the Authenticator Plus backup database into andOTP-compatible back
 
 ### With Docker
 
-```
-$ docker build -t authplus-to-andotp-magiculator .
-```
+Install [Docker](https://docs.docker.com/get-docker/).
 
 ### Without Docker
 
@@ -28,9 +26,18 @@ $ sudo python3 setup.py install
 ### With Docker:
 
 ```
-$ docker run -v ${PWD}:/authplus-to-andotp -it authplus-to-andotp-magiculator --database authplus.db
+$ docker run -v ${PWD}:/authplus-to-andotp -it adiov/authplus-to-andotp-magiculator --database authplus.db
 Authenticator Plus master password:
 andotp.json is now ready.
+```
+
+Alternatively, you can also build the image locally.
+
+```
+$ git clone https://github.com/adiov/authplus-to-andotp-magiculator.git
+$ cd authplus-to-andotp-magiculator
+$ docker build -t authplus-to-andotp-magiculator .
+$ docker run -v ${PWD}:/authplus-to-andotp -it authplus-to-andotp-magiculator --database authplus.db
 ```
 
 ### Without Docker:


### PR DESCRIPTION
Authenticator Plus uses SQLCipher v3. However, the latest SQLCipher available through common package managers is v4. Since v3 and v4 are not compatible, this is causing issues for some users.

Offering this tool through Docker seems to be a reasonable option to ensure v3 is always used, which should hopefully eliminate the compatibility issues.